### PR TITLE
fixing mistake

### DIFF
--- a/AutoHitCounter/ViewModels/SettingsViewModel.cs
+++ b/AutoHitCounter/ViewModels/SettingsViewModel.cs
@@ -106,6 +106,19 @@ public class SettingsViewModel : BaseViewModel
             SettingsManager.Default.Save();
         }
     }
+    
+    private bool _autoResetOnNewGameStart;
+
+    public bool AutoResetOnNewGameStart
+    {
+        get => _autoResetOnNewGameStart;
+        set
+        {
+            if (!SetProperty(ref _autoResetOnNewGameStart, value)) return;
+            SettingsManager.Default.AutoResetOnNewGameStart = value;
+            SettingsManager.Default.Save();
+        }
+    }
 
 
     #region Elden Ring
@@ -327,6 +340,9 @@ public class SettingsViewModel : BaseViewModel
 
         _notesDisplayMode = (NotesDisplayMode)SettingsManager.Default.NotesDisplayMode;
         OnPropertyChanged(nameof(NotesDisplayMode));
+        
+        _autoResetOnNewGameStart = SettingsManager.Default.AutoResetOnNewGameStart;
+        OnPropertyChanged(nameof(AutoResetOnNewGameStart));
         
     }
 

--- a/AutoHitCounter/Views/Controls/SettingsTab.xaml
+++ b/AutoHitCounter/Views/Controls/SettingsTab.xaml
@@ -38,8 +38,13 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,5,0,5">
                         <CheckBox Content="Always On Top"
                                   IsChecked="{Binding IsAlwaysOnTopEnabled}"
+                                  Margin="0,0,5,0" />
+                        <CheckBox Content="Auto Reset On New Game Start"
+                                  IsChecked="{Binding AutoResetOnNewGameStart}"
                                   Margin="0,0,5,0" />
                     </StackPanel>
                 </StackPanel>


### PR DESCRIPTION
because I was editing on an older version of the tool I copy pasted the settings tab and that got rid of the auto reset on new game checkbox and didn't notice that it was gone until it was mentioned to me just now, this restores the checkbox and the actual setting

basically I'm stupid 😬