### PR TITLE
Minimize groups + group count functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+.vs/
+.vscode/
+AutoHitCounter/FodyWeavers.xsd

--- a/AutoHitCounter/AutoHitCounter.csproj
+++ b/AutoHitCounter/AutoHitCounter.csproj
@@ -133,6 +133,7 @@
         <Compile Include="Enums\HotkeyActions.cs" />
         <Compile Include="Enums\SplitType.cs" />
         <Compile Include="Enums\NotesDisplayMode.cs" />
+        <Compile Include="Enums\OverlayGroupCollapseMode.cs" />
         <Compile Include="Enums\State.cs" />
         <Compile Include="Games\DS2\DS2EventService.cs" />
         <Compile Include="Games\DS2\DS2HitService.cs" />

--- a/AutoHitCounter/AutoHitCounter.csproj
+++ b/AutoHitCounter/AutoHitCounter.csproj
@@ -135,6 +135,7 @@
         <Compile Include="Enums\SplitType.cs" />
         <Compile Include="Enums\NotesDisplayMode.cs" />
         <Compile Include="Enums\OverlayGroupCollapseMode.cs" />
+        <Compile Include="Enums\OverlayGroupProgressMode.cs" />
         <Compile Include="Enums\State.cs" />
         <Compile Include="Enums\ThemeMode.cs" />
         <Compile Include="Games\DS2\DS2EventService.cs" />

--- a/AutoHitCounter/Enums/OverlayGroupCollapseMode.cs
+++ b/AutoHitCounter/Enums/OverlayGroupCollapseMode.cs
@@ -1,0 +1,17 @@
+//
+
+using System.ComponentModel;
+
+namespace AutoHitCounter.Enums;
+
+public enum OverlayGroupCollapseMode
+{
+    [Description("Collapse all inactive groups")]
+    AllInactive = 0,
+
+    [Description("Collapse only completed groups")]
+    CollapseCompletedShowFuture = 1,
+
+    [Description("Don't collapse groups")]
+    None = 2,
+}

--- a/AutoHitCounter/Enums/OverlayGroupProgressMode.cs
+++ b/AutoHitCounter/Enums/OverlayGroupProgressMode.cs
@@ -1,0 +1,17 @@
+//
+
+using System.ComponentModel;
+
+namespace AutoHitCounter.Enums;
+
+public enum OverlayGroupProgressMode
+{
+    [Description("Off")]
+    Hidden = 0,
+
+    [Description("Active group")]
+    CurrentGroupOnly = 1,
+
+    [Description("All groups")]
+    AllGroups = 2,
+}

--- a/AutoHitCounter/Models/OverlayConfig.cs
+++ b/AutoHitCounter/Models/OverlayConfig.cs
@@ -1,4 +1,6 @@
-﻿// 
+﻿//
+
+using AutoHitCounter.Enums;
 
 namespace AutoHitCounter.Models;
 
@@ -8,6 +10,7 @@ public class OverlayConfig
     public bool ShowAttempts { get; set; }
     public int PrevSplits { get; set; }
     public int NextSplits { get; set; }
+    public OverlayGroupCollapseMode GroupCollapseMode { get; set; }
     public bool ShowDiff { get; set; }
     public bool ShowPb { get; set; }
     public bool ShowIgt { get; set; }

--- a/AutoHitCounter/Models/OverlayConfig.cs
+++ b/AutoHitCounter/Models/OverlayConfig.cs
@@ -19,6 +19,7 @@ public class OverlayConfig
     public bool ShowProgress { get; set; }
     public bool ShowFooterTotals { get; set; }
     public bool ShowGroupHeaderTotals { get; set; }
+    public OverlayGroupProgressMode GroupProgressMode { get; set; }
     public bool TableMode { get; set; }
     public double BackgroundOpacity { get; set; }
     public string CustomCss { get; set; }

--- a/AutoHitCounter/Models/OverlayConfig.cs
+++ b/AutoHitCounter/Models/OverlayConfig.cs
@@ -18,7 +18,6 @@ public class OverlayConfig
     public int OverlayHeight { get; set; }
     public bool ShowProgress { get; set; }
     public bool ShowFooterTotals { get; set; }
-    public bool ShowGroupHeaderTotals { get; set; }
     public OverlayGroupProgressMode GroupProgressMode { get; set; }
     public bool TableMode { get; set; }
     public double BackgroundOpacity { get; set; }

--- a/AutoHitCounter/Models/OverlayConfig.cs
+++ b/AutoHitCounter/Models/OverlayConfig.cs
@@ -18,6 +18,7 @@ public class OverlayConfig
     public int OverlayHeight { get; set; }
     public bool ShowProgress { get; set; }
     public bool ShowFooterTotals { get; set; }
+    public bool ShowGroupHeaderTotals { get; set; }
     public bool TableMode { get; set; }
     public double BackgroundOpacity { get; set; }
     public string CustomCss { get; set; }

--- a/AutoHitCounter/Models/OverlayConfig.cs
+++ b/AutoHitCounter/Models/OverlayConfig.cs
@@ -39,6 +39,18 @@ public class OverlayConfig
     public int HeaderFontSize { get; set; }
 
 
+    // Group Header Section //
+
+    public string GroupHeaderFontFamily { get; set; }
+    public int GroupHeaderFontSize { get; set; }
+    public bool GroupHeaderBold { get; set; }
+    public bool GroupHeaderItalic { get; set; }
+    public bool GroupHeaderUnderline { get; set; }
+    public string GroupHeaderHitsColor { get; set; }
+    public string GroupHeaderHitsHighlightColor { get; set; }
+    public string GroupHeaderPbColor { get; set; }
+
+
     // Attempts Counter //
 
     public string AttemptsZeroColor { get; set; }

--- a/AutoHitCounter/Overlay.html
+++ b/AutoHitCounter/Overlay.html
@@ -287,7 +287,6 @@
                 groupCollapseMode: 2,
                 pbColor: '#bbbbbb',
                 showFooterTotals: true,
-                showGroupHeaderTotals: false,
                 groupProgressMode: 0,
                 igtFontFamily: 'Consolas',
                 igtFontSize: 17,
@@ -774,7 +773,7 @@
                         const inactiveParent = s.isParent && (collapseMode === 0
                             ? g !== activeGroup
                             : g < activeGroup);
-                        const showGroupSums = config.showGroupHeaderTotals === true;
+                        const showGroupSums = normalizedProgressMode === 2;
                         const totals = (s.isParent && inactiveParent && showGroupSums) ? (groupTotals[g] ?? null) : null;
                         const nameSuffix = s.isParent && groupProgressStrings
                             ? (groupProgressStrings[g] || '')
@@ -879,7 +878,7 @@
                 hitsCell = `<span class="col-hits" ${hitsStyle}>${totals.hits}</span>`;
                 diffCell = config.showDiff ? `<span class="col-diff ${tDiffClass}">${tDiffText}</span>` : '';
                 pbCell = config.showPb ? `<span class="col-pb">${totals.pb}</span>` : '';
-            } else if (s.isParent && inactiveParent && config.showGroupHeaderTotals !== true) {
+            } else if (s.isParent && inactiveParent && Number(config.groupProgressMode) !== 2) {
                 hitsCell = `<span class="col-hits"></span>`;
                 diffCell = config.showDiff ? `<span class="col-diff"></span>` : '';
                 pbCell = config.showPb ? `<span class="col-pb"></span>` : '';

--- a/AutoHitCounter/Overlay.html
+++ b/AutoHitCounter/Overlay.html
@@ -129,11 +129,23 @@
             background: transparent;
         }
 
-        /* Hide numbers for parent rows */
+        /* Hide numbers for parent rows 
         .split-row.parent .col-hits,
         .split-row.parent .col-diff,
         .split-row.parent .col-pb {
             visibility: hidden;
+        } */
+
+        /* Hide numbers only on the active group header (children are visible) */
+        .split-row.parent:not(.group-inactive) .col-hits,
+        .split-row.parent:not(.group-inactive) .col-diff,
+        .split-row.parent:not(.group-inactive) .col-pb {
+            visibility: hidden;
+        }
+
+        /* Collapsed rows hidden */
+        .split-row.collapsed {
+            display: none;
         }
 
         /* Diff colors - overridden dynamically */
@@ -264,6 +276,7 @@
             splitNameOnHitColor: '#e0e0e0',
             splitNameOnHitlessColor: '#e0e0e0',
             groupNameColor: '#999999',
+            collapseInactiveGroups: true,
             pbColor: '#bbbbbb',
             showFooterTotals: true,
             igtFontFamily: 'Consolas',
@@ -485,43 +498,51 @@
                 + (config.showPb ? '<span>PB</span>' : '');
         }
 
+        function computeGroupVisibility(allSplits, currentIndex) {
+            const hasGroups = allSplits.some(s => s.isParent);
+            if (!hasGroups) return null;
+
+            const groupOf = new Array(allSplits.length).fill(-1);
+            let currentGroup = -1;
+
+            for (let i = 0; i < allSplits.length; i++) {
+                if (allSplits[i].isParent) currentGroup++;
+                groupOf[i] = currentGroup;
+            }
+
+            const anchor = currentIndex >= 0 ? currentIndex : 0;
+            const activeGroup = groupOf[anchor];
+
+            const groupTotals = {};
+            for (let i = 0; i < allSplits.length; i++) {
+                const s = allSplits[i];
+                if (s.isParent) continue;
+                const g = groupOf[i];
+                if (!groupTotals[g]) groupTotals[g] = { hits: 0, pb: 0 };
+                groupTotals[g].hits += s.hits ?? 0;
+                groupTotals[g].pb += s.pb ?? 0;
+            }
+
+            for (const g of Object.keys(groupTotals)) {
+                const t = groupTotals[g];
+                t.diff = t.hits - t.pb;
+            }
+
+            return { groupOf, activeGroup, groupTotals };
+        }
 
         function renderState(state) {
             const cols = getGridColumns();
             let html = '';
 
-
-            let splits = state.splits;
-            const currentIndex = splits.findIndex(s => s.isCurrent);
-            const total = splits.length;
+            const allSplits = state.splits;
+            const currentIndex = allSplits.findIndex(s => s.isCurrent);
+            const total = allSplits.length;
             const maxRows = getVisibleRowCount();
 
             if (currentIndex >= 0) lastCurrentIndex = currentIndex;
 
             const anchor = currentIndex >= 0 ? currentIndex : lastCurrentIndex >= 0 ? lastCurrentIndex : 0;
-
-            // Use prev/next as preferences, but redistribute unused slots
-            const prevAvailable = anchor;
-            const nextAvailable = total - anchor - 1;
-            let prevWanted = config.prevSplits;
-            let nextWanted = config.nextSplits;
-
-            // If we can't fill prev, give surplus to next and vice versa
-            const prevActual = Math.min(prevWanted, prevAvailable);
-            const nextActual = Math.min(nextWanted + (prevWanted - prevActual), nextAvailable);
-            const prevFinal = Math.min(prevWanted + (nextWanted - Math.min(nextWanted, nextAvailable)), prevAvailable);
-
-            let start = Math.max(0, anchor - prevFinal);
-            let end = Math.min(total, anchor + nextActual + 1);
-
-            if (end - start > maxRows) {
-                if (anchor - start >= maxRows) {
-                    start = Math.max(0, anchor - Math.min(prevFinal, maxRows - 1));
-                }
-                end = Math.min(total, start + maxRows);
-            }
-
-            splits = splits.slice(start, end);
 
             // Distance PB
             const dpbIndex = state.distancePb ?? -1;
@@ -530,9 +551,48 @@
                 ? -1
                 : dpbIndex;
 
-            for (let i = 0; i < splits.length; i++) {
-                html += buildRow(splits[i], cols, start + i, currentIndex, dpbHighlightIndex);
+            const groupInfo = config.collapseInactiveGroups
+                ? computeGroupVisibility(allSplits, anchor)
+                : null;
+
+            if (groupInfo) {
+                const { groupOf, activeGroup, groupTotals } = groupInfo;
+                for (let i = 0; i < allSplits.length; i++) {
+                    const s = allSplits[i];
+                    const isInActiveGroup = groupOf[i] === activeGroup;
+                    const collapsed = !s.isParent && !isInActiveGroup;
+                    const inactiveParent = s.isParent && !isInActiveGroup;
+                    const totals = (s.isParent && inactiveParent) ? (groupTotals[groupOf[i]] ?? null) : null;
+                    html += buildRow(s, cols, i, currentIndex, dpbHighlightIndex, collapsed, inactiveParent, totals);
+                }
+            } else {
+                // Use prev/next as preferences, but redistribute unused slots
+                const prevAvailable = anchor;
+                const nextAvailable = total - anchor - 1;
+                let prevWanted = config.prevSplits;
+                let nextWanted = config.nextSplits;
+
+                // If we can't fill prev, give surplus to next and vice versa
+                const prevActual = Math.min(prevWanted, prevAvailable);
+                const nextActual = Math.min(nextWanted + (prevWanted - prevActual), nextAvailable);
+                const prevFinal = Math.min(prevWanted + (nextWanted - Math.min(nextWanted, nextAvailable)), prevAvailable);
+
+                let start = Math.max(0, anchor - prevFinal);
+                let end = Math.min(total, anchor + nextActual + 1);
+
+                if (end - start > maxRows) {
+                    if (anchor - start >= maxRows) {
+                        start = Math.max(0, anchor - Math.min(prevFinal, maxRows - 1));
+                    }
+                    end = Math.min(total, start + maxRows);
+                }
+
+                const windowed = allSplits.slice(start, end);
+                for (let i = 0; i < windowed.length; i++) {
+                    html += buildRow(windowed[i], cols, start + i, currentIndex, dpbHighlightIndex, false, false, null);
+                }
             }
+
             splitsEl.innerHTML = html;
 
             const footerEl = document.getElementById('footer');
@@ -578,7 +638,7 @@
             return div.innerHTML;
         }
 
-        function buildRow(s, cols, index, currentIndex, dpbHighlightIndex) {
+        function buildRow(s, cols, index, currentIndex, dpbHighlightIndex, collapsed, inactiveParent, totals) {
             const current = s.isCurrent ? ' current' : '';
             const parent = s.isParent ? ' parent' : '';
             const diffClass = s.diff > 0 ? 'diff-pos' : s.diff < 0 ? 'diff-neg' : 'diff-zero';
@@ -587,12 +647,29 @@
             const cleared = isPast && !s.isParent && s.hits === 0 ? ' cleared' : '';
             const hit = (isPast && !s.isParent && s.hits > 0) || (s.isCurrent && s.hits > 0) ? ' hit' : '';
             const dpbhighlight = index === dpbHighlightIndex ? ' pb-dpbhighlight' : '';
+            const collapsedClass = collapsed ? ' collapsed' : '';
+            const inactiveClass = inactiveParent ? ' group-inactive' : '';
 
-            return `<div class="split-row${parent}${current}${cleared}${hit}${dpbhighlight}" style="grid-template-columns: ${cols}">
+            let hitsCell, diffCell, pbCell;
+
+            if (totals) {
+                const tDiffClass = totals.diff > 0 ? 'diff-pos' : totals.diff < 0 ? 'diff-neg' : 'diff-zero';
+                const tDiffText = totals.diff > 0 ? `+${totals.diff}` : `${totals.diff}`;
+                const hitsStyle = totals.hits > 0 ? `style="color:${config.hitsActiveColor}"` : '';
+                hitsCell = `<span class="col-hits" ${hitsStyle}>${totals.hits}</span>`;
+                diffCell = config.showDiff ? `<span class="col-diff ${tDiffClass}">${tDiffText}</span>` : '';
+                pbCell = config.showPb ? `<span class="col-pb">${totals.pb}</span>` : '';
+            } else {
+                hitsCell = `<span class="col-hits">${s.hits}</span>`;
+                diffCell = config.showDiff ? `<span class="col-diff ${diffClass}">${diffText}</span>` : '';
+                pbCell = config.showPb ? `<span class="col-pb">${s.pb}</span>` : '';
+            }
+
+            return `<div class="split-row${parent}${current}${cleared}${hit}${dpbhighlight}${collapsedClass}${inactiveClass}" style="grid-template-columns: ${cols}">
                 <span class="col-name">${escapeHtml(s.name)}</span>
-                <span class="col-hits">${s.hits}</span>
-                ${config.showDiff ? `<span class="col-diff ${diffClass}">${diffText}</span>` : ''}
-                ${config.showPb ? `<span class="col-pb">${s.pb}</span>` : ''}
+                ${hitsCell}
+                ${diffCell}
+                ${pbCell}
             </div>`;
         }
 

--- a/AutoHitCounter/Overlay.html
+++ b/AutoHitCounter/Overlay.html
@@ -285,6 +285,7 @@
             pbColor: '#bbbbbb',
             showFooterTotals: true,
             showGroupHeaderTotals: false,
+            groupProgressMode: 0,
             igtFontFamily: 'Consolas',
             igtFontSize: 17,
             alternatingRows: 'rgba(255, 255, 255, 0.05)',
@@ -468,6 +469,7 @@
                     text-decoration: ${config.fontUnderline ? 'underline' : 'none'};
                 }
                 #progress { font-size: ${config.headerFontSize + 1}px; }
+                .group-progress { color: ${config.headerTextColor || '#bbbbbb'}; font-size: ${Math.max(10, (config.groupHeaderFontSize || 13) - 1)}px; font-weight: normal; }
                 #attempts { font-size: ${config.headerFontSize + 2}px; }
                 .header span:not(:first-child) { color: ${config.headerTextColor}; }
                 .igt { color: ${config.igtColor}; font-family: ${config.igtFontFamily || 'Consolas, monospace'}; font-size: ${config.igtFontSize || 16}px; }
@@ -562,6 +564,51 @@
             return { groupOf, activeGroup, groupTotals };
         }
 
+        /**
+         * @param mode 0 = hidden (caller skips), 1 = active group only, 2 = all groups
+         */
+        function computeGroupProgressStrings(allSplits, groupOf, activeGroup, anchorIdx, mode) {
+            const eff = allSplits.findIndex(s => s.isCurrent);
+            const resolved = eff >= 0 ? eff : anchorIdx;
+
+            const childrenByGroup = {};
+            for (let i = 0; i < allSplits.length; i++) {
+                if (allSplits[i].isParent) continue;
+                const g = groupOf[i];
+                if (!childrenByGroup[g]) childrenByGroup[g] = [];
+                childrenByGroup[g].push(i);
+            }
+
+            const out = {};
+            for (const g of Object.keys(childrenByGroup)) {
+                const gi = Number(g);
+                if (mode === 1 && gi !== activeGroup) {
+                    out[gi] = '';
+                    continue;
+                }
+
+                const children = childrenByGroup[g];
+                const total = children.length;
+                let cur;
+                if (children.includes(resolved)) {
+                    cur = children.indexOf(resolved) + 1;
+                } else if (gi < activeGroup) {
+                    cur = total;
+                } else if (gi > activeGroup) {
+                    cur = 0;
+                } else {
+                    let last = 0;
+                    for (const idx of children) {
+                        if (idx < resolved) last = children.indexOf(idx) + 1;
+                    }
+                    cur = last;
+                }
+
+                out[gi] = ` (${cur}/${total})`;
+            }
+            return out;
+        }
+
         function computeVisibleRowWindow(anchorPos, totalRows, maxRows) {
             const prevAvailable = anchorPos;
             const nextAvailable = totalRows - anchorPos - 1;
@@ -627,6 +674,22 @@
             if (currentIndex >= 0) lastCurrentIndex = currentIndex;
 
             const anchor = currentIndex >= 0 ? currentIndex : lastCurrentIndex >= 0 ? lastCurrentIndex : 0;
+
+            const progressModeRaw = config.groupProgressMode;
+            const progressMode = (progressModeRaw !== undefined && progressModeRaw !== null)
+                ? Number(progressModeRaw) : 0;
+            const normalizedProgressMode = (progressMode === 0 || progressMode === 1 || progressMode === 2)
+                ? progressMode : 0;
+            const hasGroups = allSplits.some(s => s.isParent);
+            const gvProgress = hasGroups ? computeGroupVisibility(allSplits, anchor) : null;
+            const groupProgressStrings = gvProgress && normalizedProgressMode > 0
+                ? computeGroupProgressStrings(
+                    allSplits,
+                    gvProgress.groupOf,
+                    gvProgress.activeGroup,
+                    anchor,
+                    normalizedProgressMode)
+                : null;
 
             // Distance PB
             const dpbIndex = state.distancePb ?? -1;
@@ -699,14 +762,23 @@
                             : g < activeGroup);
                         const showGroupSums = config.showGroupHeaderTotals === true;
                         const totals = (s.isParent && inactiveParent && showGroupSums) ? (groupTotals[g] ?? null) : null;
-                        html += buildRow(s, cols, i, currentIndex, dpbHighlightIndex, false, inactiveParent, totals);
+                        const nameSuffix = s.isParent && groupProgressStrings
+                            ? (groupProgressStrings[g] || '')
+                            : '';
+                        html += buildRow(s, cols, i, currentIndex, dpbHighlightIndex, false, inactiveParent, totals, nameSuffix);
                     }
                 }
             } else {
                 const { start, end } = computeVisibleRowWindow(anchor, total, maxRows);
                 const windowed = allSplits.slice(start, end);
                 for (let i = 0; i < windowed.length; i++) {
-                    html += buildRow(windowed[i], cols, start + i, currentIndex, dpbHighlightIndex, false, false, null);
+                    const idx = start + i;
+                    const s = windowed[i];
+                    const g = gvProgress ? gvProgress.groupOf[idx] : -1;
+                    const nameSuffix = s.isParent && groupProgressStrings && g >= 0
+                        ? (groupProgressStrings[g] || '')
+                        : '';
+                    html += buildRow(s, cols, idx, currentIndex, dpbHighlightIndex, false, false, null, nameSuffix);
                 }
             }
 
@@ -756,7 +828,14 @@
             return div.innerHTML;
         }
 
-        function buildRow(s, cols, index, currentIndex, dpbHighlightIndex, collapsed, inactiveParent, totals) {
+        function buildRow(s, cols, index, currentIndex, dpbHighlightIndex, collapsed, inactiveParent, totals, groupNameSuffix) {
+            const nameExtra = groupNameSuffix || '';
+            let nameHtml;
+            if (s.isParent && nameExtra) {
+                nameHtml = `${escapeHtml(s.name)}<span class="group-progress">${nameExtra}</span>`;
+            } else {
+                nameHtml = escapeHtml(s.name) + nameExtra;
+            }
             const current = s.isCurrent ? ' current' : '';
             const parent = s.isParent ? ' parent' : '';
             const diffClass = s.diff > 0 ? 'diff-pos' : s.diff < 0 ? 'diff-neg' : 'diff-zero';
@@ -789,7 +868,7 @@
             }
 
             return `<div class="split-row${parent}${current}${cleared}${hit}${dpbhighlight}${collapsedClass}${inactiveClass}" style="grid-template-columns: ${cols}">
-                <span class="col-name">${escapeHtml(s.name)}</span>
+                <span class="col-name">${nameHtml}</span>
                 ${hitsCell}
                 ${diffCell}
                 ${pbCell}

--- a/AutoHitCounter/Overlay.html
+++ b/AutoHitCounter/Overlay.html
@@ -276,7 +276,7 @@
             splitNameOnHitColor: '#e0e0e0',
             splitNameOnHitlessColor: '#e0e0e0',
             groupNameColor: '#999999',
-            collapseInactiveGroups: true,
+            groupCollapseMode: 2,
             pbColor: '#bbbbbb',
             showFooterTotals: true,
             igtFontFamily: 'Consolas',
@@ -312,6 +312,17 @@
             }
         }
 
+        function applyLegacyGroupCollapse() {
+            if (config.groupCollapseMode === undefined || config.groupCollapseMode === null) {
+                config.groupCollapseMode = config.collapseInactiveGroups === false ? 2 : 0;
+            } else {
+                const n = Number(config.groupCollapseMode);
+                config.groupCollapseMode = (n === 0 || n === 1 || n === 2) ? n : 0;
+            }
+        }
+
+        applyLegacyGroupCollapse();
+
         const overlay = document.getElementById('overlay');
         const headerEl = document.getElementById('header');
         const splitsEl = document.getElementById('splits');
@@ -343,6 +354,7 @@
                     }
                 } else if (msg.type === 'config') {
                     Object.assign(config, msg.data);
+                    applyLegacyGroupCollapse();
                     localStorage.setItem('overlayConfig', JSON.stringify(config));
                     applyLayout();
                     if (lastState) renderState(lastState);
@@ -554,14 +566,17 @@
             return { start, end };
         }
 
-        function buildCollapseVisibleIndices(allSplits, groupOf, activeGroup) {
+        /** @param mode 0 = all inactive collapsed, 1 = completed collapsed + future expanded */
+        function buildCollapseVisibleIndices(allSplits, groupOf, activeGroup, mode) {
             const indices = [];
             for (let i = 0; i < allSplits.length; i++) {
                 const s = allSplits[i];
-                const inActive = groupOf[i] === activeGroup;
+                const g = groupOf[i];
+                const inActive = g === activeGroup;
+                const inFuture = g > activeGroup;
                 if (s.isParent) {
                     indices.push(i);
-                } else if (inActive) {
+                } else if (mode === 1 ? (inActive || inFuture) : inActive) {
                     indices.push(i);
                 }
             }
@@ -588,13 +603,16 @@
                 ? -1
                 : dpbIndex;
 
-            const groupInfo = config.collapseInactiveGroups
+            let collapseMode = Number(config.groupCollapseMode);
+            if (collapseMode !== 0 && collapseMode !== 1 && collapseMode !== 2) collapseMode = 0;
+
+            const groupInfo = collapseMode !== 2
                 ? computeGroupVisibility(allSplits, anchor)
                 : null;
 
             if (groupInfo) {
                 const { groupOf, activeGroup, groupTotals } = groupInfo;
-                const visibleIndices = buildCollapseVisibleIndices(allSplits, groupOf, activeGroup);
+                const visibleIndices = buildCollapseVisibleIndices(allSplits, groupOf, activeGroup, collapseMode);
                 if (visibleIndices.length > 0) {
                     let anchorPos = visibleIndices.indexOf(anchor);
                     if (anchorPos < 0) {
@@ -614,9 +632,11 @@
                     for (let j = wStart; j < wEnd; j++) {
                         const i = visibleIndices[j];
                         const s = allSplits[i];
-                        const isInActiveGroup = groupOf[i] === activeGroup;
-                        const inactiveParent = s.isParent && !isInActiveGroup;
-                        const totals = (s.isParent && inactiveParent) ? (groupTotals[groupOf[i]] ?? null) : null;
+                        const g = groupOf[i];
+                        const inactiveParent = s.isParent && (collapseMode === 0
+                            ? g !== activeGroup
+                            : g < activeGroup);
+                        const totals = (s.isParent && inactiveParent) ? (groupTotals[g] ?? null) : null;
                         html += buildRow(s, cols, i, currentIndex, dpbHighlightIndex, false, inactiveParent, totals);
                     }
                 }

--- a/AutoHitCounter/Overlay.html
+++ b/AutoHitCounter/Overlay.html
@@ -531,6 +531,43 @@
             return { groupOf, activeGroup, groupTotals };
         }
 
+        function computeVisibleRowWindow(anchorPos, totalRows, maxRows) {
+            const prevAvailable = anchorPos;
+            const nextAvailable = totalRows - anchorPos - 1;
+            const prevWanted = config.prevSplits;
+            const nextWanted = config.nextSplits;
+
+            const prevActual = Math.min(prevWanted, prevAvailable);
+            const nextActual = Math.min(nextWanted + (prevWanted - prevActual), nextAvailable);
+            const prevFinal = Math.min(prevWanted + (nextWanted - Math.min(nextWanted, nextAvailable)), prevAvailable);
+
+            let start = Math.max(0, anchorPos - prevFinal);
+            let end = Math.min(totalRows, anchorPos + nextActual + 1);
+
+            if (end - start > maxRows) {
+                if (anchorPos - start >= maxRows) {
+                    start = Math.max(0, anchorPos - Math.min(prevFinal, maxRows - 1));
+                }
+                end = Math.min(totalRows, start + maxRows);
+            }
+
+            return { start, end };
+        }
+
+        function buildCollapseVisibleIndices(allSplits, groupOf, activeGroup) {
+            const indices = [];
+            for (let i = 0; i < allSplits.length; i++) {
+                const s = allSplits[i];
+                const inActive = groupOf[i] === activeGroup;
+                if (s.isParent) {
+                    indices.push(i);
+                } else if (inActive) {
+                    indices.push(i);
+                }
+            }
+            return indices;
+        }
+
         function renderState(state) {
             const cols = getGridColumns();
             let html = '';
@@ -557,36 +594,34 @@
 
             if (groupInfo) {
                 const { groupOf, activeGroup, groupTotals } = groupInfo;
-                for (let i = 0; i < allSplits.length; i++) {
-                    const s = allSplits[i];
-                    const isInActiveGroup = groupOf[i] === activeGroup;
-                    const collapsed = !s.isParent && !isInActiveGroup;
-                    const inactiveParent = s.isParent && !isInActiveGroup;
-                    const totals = (s.isParent && inactiveParent) ? (groupTotals[groupOf[i]] ?? null) : null;
-                    html += buildRow(s, cols, i, currentIndex, dpbHighlightIndex, collapsed, inactiveParent, totals);
+                const visibleIndices = buildCollapseVisibleIndices(allSplits, groupOf, activeGroup);
+                if (visibleIndices.length > 0) {
+                    let anchorPos = visibleIndices.indexOf(anchor);
+                    if (anchorPos < 0) {
+                        let best = 0;
+                        for (let p = 0; p < visibleIndices.length; p++) {
+                            if (visibleIndices[p] <= anchor) best = p;
+                            else break;
+                        }
+                        anchorPos = best;
+                    }
+
+                    const { start: wStart, end: wEnd } = computeVisibleRowWindow(
+                        anchorPos,
+                        visibleIndices.length,
+                        maxRows
+                    );
+                    for (let j = wStart; j < wEnd; j++) {
+                        const i = visibleIndices[j];
+                        const s = allSplits[i];
+                        const isInActiveGroup = groupOf[i] === activeGroup;
+                        const inactiveParent = s.isParent && !isInActiveGroup;
+                        const totals = (s.isParent && inactiveParent) ? (groupTotals[groupOf[i]] ?? null) : null;
+                        html += buildRow(s, cols, i, currentIndex, dpbHighlightIndex, false, inactiveParent, totals);
+                    }
                 }
             } else {
-                // Use prev/next as preferences, but redistribute unused slots
-                const prevAvailable = anchor;
-                const nextAvailable = total - anchor - 1;
-                let prevWanted = config.prevSplits;
-                let nextWanted = config.nextSplits;
-
-                // If we can't fill prev, give surplus to next and vice versa
-                const prevActual = Math.min(prevWanted, prevAvailable);
-                const nextActual = Math.min(nextWanted + (prevWanted - prevActual), nextAvailable);
-                const prevFinal = Math.min(prevWanted + (nextWanted - Math.min(nextWanted, nextAvailable)), prevAvailable);
-
-                let start = Math.max(0, anchor - prevFinal);
-                let end = Math.min(total, anchor + nextActual + 1);
-
-                if (end - start > maxRows) {
-                    if (anchor - start >= maxRows) {
-                        start = Math.max(0, anchor - Math.min(prevFinal, maxRows - 1));
-                    }
-                    end = Math.min(total, start + maxRows);
-                }
-
+                const { start, end } = computeVisibleRowWindow(anchor, total, maxRows);
                 const windowed = allSplits.slice(start, end);
                 for (let i = 0; i < windowed.length; i++) {
                     html += buildRow(windowed[i], cols, start + i, currentIndex, dpbHighlightIndex, false, false, null);

--- a/AutoHitCounter/Overlay.html
+++ b/AutoHitCounter/Overlay.html
@@ -279,6 +279,7 @@
             groupCollapseMode: 2,
             pbColor: '#bbbbbb',
             showFooterTotals: true,
+            showGroupHeaderTotals: false,
             igtFontFamily: 'Consolas',
             igtFontSize: 17,
             alternatingRows: 'rgba(255, 255, 255, 0.05)',
@@ -636,7 +637,8 @@
                         const inactiveParent = s.isParent && (collapseMode === 0
                             ? g !== activeGroup
                             : g < activeGroup);
-                        const totals = (s.isParent && inactiveParent) ? (groupTotals[g] ?? null) : null;
+                        const showGroupSums = config.showGroupHeaderTotals === true;
+                        const totals = (s.isParent && inactiveParent && showGroupSums) ? (groupTotals[g] ?? null) : null;
                         html += buildRow(s, cols, i, currentIndex, dpbHighlightIndex, false, inactiveParent, totals);
                     }
                 }
@@ -715,6 +717,10 @@
                 hitsCell = `<span class="col-hits" ${hitsStyle}>${totals.hits}</span>`;
                 diffCell = config.showDiff ? `<span class="col-diff ${tDiffClass}">${tDiffText}</span>` : '';
                 pbCell = config.showPb ? `<span class="col-pb">${totals.pb}</span>` : '';
+            } else if (s.isParent && inactiveParent && config.showGroupHeaderTotals !== true) {
+                hitsCell = `<span class="col-hits"></span>`;
+                diffCell = config.showDiff ? `<span class="col-diff"></span>` : '';
+                pbCell = config.showPb ? `<span class="col-pb"></span>` : '';
             } else {
                 hitsCell = `<span class="col-hits">${s.hits}</span>`;
                 diffCell = config.showDiff ? `<span class="col-diff ${diffClass}">${diffText}</span>` : '';

--- a/AutoHitCounter/Overlay.html
+++ b/AutoHitCounter/Overlay.html
@@ -118,12 +118,9 @@
         }
 
 
-        /* Parent category row styling */
+        /* Parent category row — font size/weight/color come from applyDynamicStyles */
         .split-row.parent {
-            font-weight: 700;
-            font-size: 13px;
             letter-spacing: 0.03em;
-            color: #999;
             padding-top: 8px;
             border-left-color: transparent;
             background: transparent;
@@ -276,6 +273,14 @@
             splitNameOnHitColor: '#e0e0e0',
             splitNameOnHitlessColor: '#e0e0e0',
             groupNameColor: '#999999',
+            groupHeaderFontFamily: 'Segoe UI',
+            groupHeaderFontSize: 13,
+            groupHeaderBold: true,
+            groupHeaderItalic: false,
+            groupHeaderUnderline: false,
+            groupHeaderHitsColor: '#888888',
+            groupHeaderHitsHighlightColor: '#c8843a',
+            groupHeaderPbColor: '#bbbbbb',
             groupCollapseMode: 2,
             pbColor: '#bbbbbb',
             showFooterTotals: true,
@@ -389,6 +394,10 @@
                 dynamicStyleEl = document.createElement('style');
                 document.head.appendChild(dynamicStyleEl);
             }
+            const ghFam = config.groupHeaderFontFamily || config.fontFamily || 'Segoe UI';
+            const ghSize = (config.groupHeaderFontSize > 0) ? config.groupHeaderFontSize : 13;
+            const ghHits = config.groupHeaderHitsColor || config.hitsCurrentColor;
+            const ghPb = config.groupHeaderPbColor || config.pbColor;
             dynamicStyleEl.textContent = `
                 .diff-pos { color: ${config.diffPosColor}; }
                 .diff-neg { color: ${config.diffNegColor}; }
@@ -424,7 +433,7 @@
                 .split-row .col-name { color: ${config.splitNameColor}; }
                 .split-row.hit .col-name { color: ${config.splitNameOnHitColor}; }
                 .split-row.cleared .col-name { color: ${config.splitNameOnHitlessColor}; }
-                .split-row.parent { color: ${config.groupNameColor}; }
+                .split-row.parent .col-name { color: ${config.groupNameColor}; }
                 .split-row .col-hits { color: ${config.hitsCurrentColor}; }
                 .split-row.cleared .col-hits { color: ${config.hitsClearedColor}; }
                 .split-row.hit .col-hits { color: ${config.hitsActiveColor}; }
@@ -433,9 +442,18 @@
                 .split-row.hit .col-pb { color: ${config.pbMatchesHit ? config.hitsActiveColor : config.pbColor}; }
                 .split-row.cleared .col-pb { color: ${config.pbMatchesHit ? config.hitsClearedColor : config.pbColor}; }
                 .split-row.current.hit .col-pb { color: ${config.pbMatchesHit ? config.hitsActiveColor : config.pbColor}; }
+                .split-row.parent .col-hits { color: ${ghHits}; }
+                .split-row.parent .col-pb { color: ${ghPb}; }
+                .split-row.parent {
+                    font-family: ${ghFam};
+                    font-size: ${ghSize}px;
+                    font-weight: ${config.groupHeaderBold !== false ? 'bold' : 'normal'};
+                    font-style: ${config.groupHeaderItalic ? 'italic' : 'normal'};
+                    text-decoration: ${config.groupHeaderUnderline ? 'underline' : 'none'};
+                }
                 .footer .col-hits { color: ${config.footerHitFontColor}; }
                 .footer .col-pb { color: ${config.footerPbFontColor}; }
-                #overlay, .split-row, .footer { 
+                #overlay, .split-row:not(.parent), .footer { 
                     font-weight: ${config.fontBold ? 'bold' : 'normal'};
                     font-style: ${config.fontItalic ? 'italic' : 'normal'};
                     text-decoration: ${config.fontUnderline ? 'underline' : 'none'};
@@ -713,7 +731,8 @@
             if (totals) {
                 const tDiffClass = totals.diff > 0 ? 'diff-pos' : totals.diff < 0 ? 'diff-neg' : 'diff-zero';
                 const tDiffText = totals.diff > 0 ? `+${totals.diff}` : `${totals.diff}`;
-                const hitsStyle = totals.hits > 0 ? `style="color:${config.hitsActiveColor}"` : '';
+                const ghHighlight = config.groupHeaderHitsHighlightColor || config.hitsActiveColor;
+                const hitsStyle = totals.hits > 0 ? `style="color:${ghHighlight}"` : '';
                 hitsCell = `<span class="col-hits" ${hitsStyle}>${totals.hits}</span>`;
                 diffCell = config.showDiff ? `<span class="col-diff ${tDiffClass}">${tDiffText}</span>` : '';
                 pbCell = config.showPb ? `<span class="col-pb">${totals.pb}</span>` : '';

--- a/AutoHitCounter/Overlay.html
+++ b/AutoHitCounter/Overlay.html
@@ -602,6 +602,19 @@
             return indices;
         }
 
+        function findActiveGroupHeaderIndex(allSplits, groupOf, activeGroup) {
+            for (let i = 0; i < allSplits.length; i++) {
+                if (allSplits[i].isParent && groupOf[i] === activeGroup) return i;
+            }
+            return -1;
+        }
+
+        function shouldPinActiveGroupHeader(activeHeaderPos, windowStart, renderIndices, activeHeaderIndex) {
+            return activeHeaderPos >= 0
+                && activeHeaderPos < windowStart
+                && !renderIndices.includes(activeHeaderIndex);
+        }
+
         function renderState(state) {
             const cols = getGridColumns();
             let html = '';
@@ -643,13 +656,42 @@
                         anchorPos = best;
                     }
 
+                    const activeHeaderIndex = findActiveGroupHeaderIndex(allSplits, groupOf, activeGroup);
+                    const activeHeaderPos = activeHeaderIndex >= 0 ? visibleIndices.indexOf(activeHeaderIndex) : -1;
+
                     const { start: wStart, end: wEnd } = computeVisibleRowWindow(
                         anchorPos,
                         visibleIndices.length,
                         maxRows
                     );
-                    for (let j = wStart; j < wEnd; j++) {
-                        const i = visibleIndices[j];
+                    const shouldPinActiveHeader = shouldPinActiveGroupHeader(
+                        activeHeaderPos,
+                        wStart,
+                        visibleIndices.slice(wStart, wEnd),
+                        activeHeaderIndex
+                    );
+                    const effectiveStart = (shouldPinActiveHeader && wStart < anchorPos) ? (wStart + 1) : wStart;
+                    let renderIndices = visibleIndices.slice(effectiveStart, wEnd);
+
+                    if (shouldPinActiveHeader) {
+                        renderIndices.unshift(activeHeaderIndex);
+                        const allowedRows = maxRows + 1;
+                        if (renderIndices.length > allowedRows) {
+                            // Preserve current split and pinned header while enforcing frozen-header cap.
+                            let trimAt = -1;
+                            for (let r = renderIndices.length - 1; r >= 0; r--) {
+                                const idx = renderIndices[r];
+                                if (idx !== anchor && idx !== activeHeaderIndex) {
+                                    trimAt = r;
+                                    break;
+                                }
+                            }
+                            if (trimAt === -1) trimAt = renderIndices.length - 1;
+                            renderIndices.splice(trimAt, 1);
+                        }
+                    }
+
+                    for (const i of renderIndices) {
                         const s = allSplits[i];
                         const g = groupOf[i];
                         const inactiveParent = s.isParent && (collapseMode === 0

--- a/AutoHitCounter/Overlay.html
+++ b/AutoHitCounter/Overlay.html
@@ -121,7 +121,7 @@
         /* Parent category row — font size/weight/color come from applyDynamicStyles */
         .split-row.parent {
             letter-spacing: 0.03em;
-            padding-top: 8px;
+            align-items: center; 
             border-left-color: transparent;
             background: transparent;
         }

--- a/AutoHitCounter/Utilities/OverlayProfileManager.cs
+++ b/AutoHitCounter/Utilities/OverlayProfileManager.cs
@@ -200,6 +200,7 @@ public class OverlayProfileManager
             ShowProgress = true,
             ShowFooterTotals = true,
             ShowGroupHeaderTotals = false,
+            GroupProgressMode = OverlayGroupProgressMode.Hidden,
             TableMode = false,
             BackgroundOpacity = 0,
 

--- a/AutoHitCounter/Utilities/OverlayProfileManager.cs
+++ b/AutoHitCounter/Utilities/OverlayProfileManager.cs
@@ -199,7 +199,6 @@ public class OverlayProfileManager
             OverlayHeight = 500,
             ShowProgress = true,
             ShowFooterTotals = true,
-            ShowGroupHeaderTotals = false,
             GroupProgressMode = OverlayGroupProgressMode.Hidden,
             TableMode = false,
             BackgroundOpacity = 0,

--- a/AutoHitCounter/Utilities/OverlayProfileManager.cs
+++ b/AutoHitCounter/Utilities/OverlayProfileManager.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
+using AutoHitCounter.Enums;
 using AutoHitCounter.Models;
 
 namespace AutoHitCounter.Utilities;
@@ -163,6 +164,7 @@ public class OverlayProfileManager
             ShowAttempts = true,
             PrevSplits = 4,
             NextSplits = 10,
+            GroupCollapseMode = OverlayGroupCollapseMode.None,
             ShowDiff = true,
             ShowPb = true,
             ShowIgt = true,

--- a/AutoHitCounter/Utilities/OverlayProfileManager.cs
+++ b/AutoHitCounter/Utilities/OverlayProfileManager.cs
@@ -57,12 +57,39 @@ public class OverlayProfileManager
         try
         {
             var json = File.ReadAllText(path);
-            return JsonSerializer.Deserialize<OverlayConfig>(json, ReadOptions) ?? CreateDefaultConfig();
+            var config = JsonSerializer.Deserialize<OverlayConfig>(json, ReadOptions) ?? CreateDefaultConfig();
+            EnsureGroupHeaderDefaults(config);
+            return config;
         }
         catch
         {
             return CreateDefaultConfig();
         }
+    }
+
+    /// <summary>
+    /// Fills group-header fields when loading profiles saved before those properties existed.
+    /// </summary>
+    private static void EnsureGroupHeaderDefaults(OverlayConfig c)
+    {
+        var d = CreateDefaultConfig();
+        if (c.GroupHeaderFontSize <= 0)
+        {
+            c.GroupHeaderFontFamily = d.GroupHeaderFontFamily;
+            c.GroupHeaderFontSize = d.GroupHeaderFontSize;
+            c.GroupHeaderBold = d.GroupHeaderBold;
+            c.GroupHeaderItalic = d.GroupHeaderItalic;
+            c.GroupHeaderUnderline = d.GroupHeaderUnderline;
+            c.GroupHeaderHitsColor = d.GroupHeaderHitsColor;
+            c.GroupHeaderHitsHighlightColor = d.GroupHeaderHitsHighlightColor;
+            c.GroupHeaderPbColor = d.GroupHeaderPbColor;
+            return;
+        }
+
+        if (string.IsNullOrEmpty(c.GroupHeaderHitsColor)) c.GroupHeaderHitsColor = d.GroupHeaderHitsColor;
+        if (string.IsNullOrEmpty(c.GroupHeaderHitsHighlightColor)) c.GroupHeaderHitsHighlightColor = d.GroupHeaderHitsHighlightColor;
+        if (string.IsNullOrEmpty(c.GroupHeaderPbColor)) c.GroupHeaderPbColor = d.GroupHeaderPbColor;
+        if (string.IsNullOrEmpty(c.GroupHeaderFontFamily)) c.GroupHeaderFontFamily = d.GroupHeaderFontFamily;
     }
 
     public void SaveActiveProfile(OverlayConfig config)
@@ -185,6 +212,15 @@ public class OverlayProfileManager
             HeaderTextColor = "#bbbbbb",
             HeaderFontFamily = "Segoe UI",
             HeaderFontSize = 13,
+
+            GroupHeaderFontFamily = "Segoe UI",
+            GroupHeaderFontSize = 13,
+            GroupHeaderBold = true,
+            GroupHeaderItalic = false,
+            GroupHeaderUnderline = false,
+            GroupHeaderHitsColor = "#888888",
+            GroupHeaderHitsHighlightColor = "#c8843a",
+            GroupHeaderPbColor = "#bbbbbb",
 
             AttemptsZeroColor = "#ffffff",
             AttemptsActiveColor = "#9D61A8",

--- a/AutoHitCounter/Utilities/OverlayProfileManager.cs
+++ b/AutoHitCounter/Utilities/OverlayProfileManager.cs
@@ -172,6 +172,7 @@ public class OverlayProfileManager
             OverlayHeight = 500,
             ShowProgress = true,
             ShowFooterTotals = true,
+            ShowGroupHeaderTotals = false,
             TableMode = false,
             BackgroundOpacity = 0,
 

--- a/AutoHitCounter/ViewModels/OverlaySettingsViewModel.cs
+++ b/AutoHitCounter/ViewModels/OverlaySettingsViewModel.cs
@@ -124,7 +124,6 @@ public class OverlaySettingsViewModel : BaseViewModel
     public bool ShowPb            { get => Get<bool>();   set => Set(value); }
     public bool ShowIgt           { get => Get<bool>();   set => Set(value); }
     public bool ShowFooterTotals  { get => Get<bool>();   set => Set(value); }
-    public bool ShowGroupHeaderTotals { get => Get<bool>(); set => Set(value); }
     public OverlayGroupProgressMode GroupProgressMode { get => Get<OverlayGroupProgressMode>(); set => Set(value); }
     public int  PrevSplits        { get => Get<int>();    set => Set(value); }
     public int  NextSplits        { get => Get<int>();    set => Set(value); }

--- a/AutoHitCounter/ViewModels/OverlaySettingsViewModel.cs
+++ b/AutoHitCounter/ViewModels/OverlaySettingsViewModel.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Windows.Media;
 using AutoHitCounter.Core;
+using AutoHitCounter.Enums;
 using AutoHitCounter.Models;
 using AutoHitCounter.Services;
 using AutoHitCounter.Utilities;
@@ -25,6 +26,9 @@ public class OverlaySettingsViewModel : BaseViewModel
         .Select(f => f.Source)
         .OrderBy(f => f)
         .ToList();
+
+    public IReadOnlyList<OverlayGroupCollapseMode> GroupCollapseModes { get; } =
+        EnumExtensions.GetValues<OverlayGroupCollapseMode>().ToList();
 
     public OverlaySettingsViewModel(OverlayServerService overlayServerService, OverlayProfileManager profileManager)
     {
@@ -115,6 +119,7 @@ public class OverlaySettingsViewModel : BaseViewModel
     public bool ShowFooterTotals  { get => Get<bool>();   set => Set(value); }
     public int  PrevSplits        { get => Get<int>();    set => Set(value); }
     public int  NextSplits        { get => Get<int>();    set => Set(value); }
+    public OverlayGroupCollapseMode GroupCollapseMode { get => Get<OverlayGroupCollapseMode>(); set => Set(value); }
     public int  OverlayWidth      { get => Get<int>();    set => Set(value); }
     public int  OverlayHeight     { get => Get<int>();    set => Set(value); }
     public double BackgroundOpacity { get => Get<double>(); set => Set(value); }

--- a/AutoHitCounter/ViewModels/OverlaySettingsViewModel.cs
+++ b/AutoHitCounter/ViewModels/OverlaySettingsViewModel.cs
@@ -30,6 +30,9 @@ public class OverlaySettingsViewModel : BaseViewModel
     public IReadOnlyList<OverlayGroupCollapseMode> GroupCollapseModes { get; } =
         EnumExtensions.GetValues<OverlayGroupCollapseMode>().ToList();
 
+    public IReadOnlyList<OverlayGroupProgressMode> GroupProgressModes { get; } =
+        EnumExtensions.GetValues<OverlayGroupProgressMode>().ToList();
+
     public OverlaySettingsViewModel(OverlayServerService overlayServerService, OverlayProfileManager profileManager)
     {
         _overlayServerService = overlayServerService;
@@ -118,6 +121,7 @@ public class OverlaySettingsViewModel : BaseViewModel
     public bool ShowIgt           { get => Get<bool>();   set => Set(value); }
     public bool ShowFooterTotals  { get => Get<bool>();   set => Set(value); }
     public bool ShowGroupHeaderTotals { get => Get<bool>(); set => Set(value); }
+    public OverlayGroupProgressMode GroupProgressMode { get => Get<OverlayGroupProgressMode>(); set => Set(value); }
     public int  PrevSplits        { get => Get<int>();    set => Set(value); }
     public int  NextSplits        { get => Get<int>();    set => Set(value); }
     public OverlayGroupCollapseMode GroupCollapseMode { get => Get<OverlayGroupCollapseMode>(); set => Set(value); }

--- a/AutoHitCounter/ViewModels/OverlaySettingsViewModel.cs
+++ b/AutoHitCounter/ViewModels/OverlaySettingsViewModel.cs
@@ -174,6 +174,16 @@ public class OverlaySettingsViewModel : BaseViewModel
     public string HitsClearedColor          { get => Get<string>(); set => Set(value); }
     public string HeaderFontFamily          { get => Get<string>(); set => Set(value); }
     public int HeaderFontSize          { get => Get<int>(); set => Set(value); }
+
+    public string GroupHeaderFontFamily   { get => Get<string>(); set => Set(value); }
+    public int    GroupHeaderFontSize     { get => Get<int>(); set => Set(value); }
+    public bool   GroupHeaderBold         { get => Get<bool>(); set => Set(value); }
+    public bool   GroupHeaderItalic       { get => Get<bool>(); set => Set(value); }
+    public bool   GroupHeaderUnderline    { get => Get<bool>(); set => Set(value); }
+    public string GroupHeaderHitsColor           { get => Get<string>(); set => Set(value); }
+    public string GroupHeaderHitsHighlightColor { get => Get<string>(); set => Set(value); }
+    public string GroupHeaderPbColor             { get => Get<string>(); set => Set(value); }
+
     public bool PbMatchesHit { get => Get<bool>(); set => Set(value); }
     public string FooterHitFontColor          { get => Get<string>(); set => Set(value); }
     public string FooterHitsCurrentColor          { get => Get<string>(); set => Set(value); }

--- a/AutoHitCounter/ViewModels/OverlaySettingsViewModel.cs
+++ b/AutoHitCounter/ViewModels/OverlaySettingsViewModel.cs
@@ -117,6 +117,7 @@ public class OverlaySettingsViewModel : BaseViewModel
     public bool ShowPb            { get => Get<bool>();   set => Set(value); }
     public bool ShowIgt           { get => Get<bool>();   set => Set(value); }
     public bool ShowFooterTotals  { get => Get<bool>();   set => Set(value); }
+    public bool ShowGroupHeaderTotals { get => Get<bool>(); set => Set(value); }
     public int  PrevSplits        { get => Get<int>();    set => Set(value); }
     public int  NextSplits        { get => Get<int>();    set => Set(value); }
     public OverlayGroupCollapseMode GroupCollapseMode { get => Get<OverlayGroupCollapseMode>(); set => Set(value); }

--- a/AutoHitCounter/Views/Windows/OverlaySettingsWindow.xaml
+++ b/AutoHitCounter/Views/Windows/OverlaySettingsWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         xmlns:controls="clr-namespace:AutoHitCounter.Views.Controls"
+        xmlns:converters="clr-namespace:AutoHitCounter.Converters"
         Style="{StaticResource DefaultWindowStyle}"
         WindowStyle="None"
         AllowsTransparency="True"
@@ -13,6 +14,8 @@
         ResizeMode="NoResize">
 
     <Window.Resources>
+
+        <converters:EnumDescriptionConverter x:Key="EnumDescriptionConverter" />
 
         <Style x:Key="PanelBorder" TargetType="Border">
             <Setter Property="BorderBrush" Value="#2a2a2a" />
@@ -141,6 +144,19 @@
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
                             <TextBlock Text="Next Splits" Style="{StaticResource FieldLabel}" Width="80" />
                             <xctk:IntegerUpDown Value="{Binding NextSplits}" Minimum="1" Maximum="50" Width="55" />
+                        </StackPanel>
+                        <StackPanel Margin="0,0,0,4">
+                            <TextBlock Text="Group collapse" Style="{StaticResource FieldLabel}" Width="Auto"
+                                       Margin="0,0,0,2" />
+                            <ComboBox ItemsSource="{Binding GroupCollapseModes}"
+                                      SelectedItem="{Binding GroupCollapseMode}"
+                                      FontSize="11" Width="175">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Converter={StaticResource EnumDescriptionConverter}}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
                         </StackPanel>
 
                         <Separator Style="{StaticResource Separator}" />

--- a/AutoHitCounter/Views/Windows/OverlaySettingsWindow.xaml
+++ b/AutoHitCounter/Views/Windows/OverlaySettingsWindow.xaml
@@ -139,7 +139,6 @@
                         <CheckBox Content="Show Progress Bar" IsChecked="{Binding ShowProgressBar}" Margin="0,2,0,2" />
                         <CheckBox Content="Show Distance PB" IsChecked="{Binding ShowDpbHighlight}" Margin="0,2,0,2" />
                         <CheckBox Content="Show Footer Totals" IsChecked="{Binding ShowFooterTotals}" Margin="0,2,0,2" />
-                        <CheckBox Content="Show Group Totals" IsChecked="{Binding ShowGroupHeaderTotals}" Margin="0,2,0,2" />
                         <CheckBox Content="Show Header Border" IsChecked="{Binding ShowHeaderBorder}" Margin="0,2,0,2" />
                         <CheckBox Content="Show Footer Border" IsChecked="{Binding ShowFooterBorder}" Margin="0,2,0,2" />
                         <CheckBox Content="Show Run Complete" IsChecked="{Binding ShowRunComplete}" Margin="0,2,0,2" />

--- a/AutoHitCounter/Views/Windows/OverlaySettingsWindow.xaml
+++ b/AutoHitCounter/Views/Windows/OverlaySettingsWindow.xaml
@@ -168,6 +168,20 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
                         </StackPanel>
+                        <StackPanel Margin="0,0,0,4">
+                            <TextBlock Text="Group progress" Style="{StaticResource FieldLabel}" Width="Auto"
+                                       Margin="0,0,0,2" />
+                            <ComboBox ItemsSource="{Binding GroupProgressModes}"
+                                      SelectedItem="{Binding GroupProgressMode}"
+                                      FontSize="11" Width="184"
+                                      HorizontalAlignment="Left">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Converter={StaticResource EnumDescriptionConverter}}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
 
                         <Separator Style="{StaticResource Separator}" />
                         <TextBlock Text="DIMENSIONS" Style="{StaticResource SectionLabel}" />

--- a/AutoHitCounter/Views/Windows/OverlaySettingsWindow.xaml
+++ b/AutoHitCounter/Views/Windows/OverlaySettingsWindow.xaml
@@ -138,6 +138,7 @@
                         <CheckBox Content="Show Progress" IsChecked="{Binding ShowProgress}" Margin="0,2,0,2" />
                         <CheckBox Content="Show Distance PB" IsChecked="{Binding ShowDpbHighlight}" Margin="0,2,0,2" />
                         <CheckBox Content="Show Footer Totals" IsChecked="{Binding ShowFooterTotals}" Margin="0,2,0,2" />
+                        <CheckBox Content="Show Group Totals" IsChecked="{Binding ShowGroupHeaderTotals}" Margin="0,2,0,2" />
                         <CheckBox Content="Show Run Complete" IsChecked="{Binding ShowRunComplete}" Margin="0,2,0,2" />
                         <CheckBox Content="Table Mode" IsChecked="{Binding TableMode}" Margin="0,2,0,2" />
                         <CheckBox Content="PB Color Matches Hit" IsChecked="{Binding PbMatchesHit}" Margin="0,2,0,2" />

--- a/AutoHitCounter/Views/Windows/OverlaySettingsWindow.xaml
+++ b/AutoHitCounter/Views/Windows/OverlaySettingsWindow.xaml
@@ -10,8 +10,8 @@
         AllowsTransparency="True"
         Background="Transparent"
         Title="Overlay Settings"
-        Width="920" Height="700"
-        MinWidth="920" MinHeight="700"
+        Width="920" Height="720"
+        MinWidth="920" MinHeight="720"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
                        behaviors:WindowResizeBehavior.EnableCustomResize="True">
@@ -67,7 +67,7 @@
     <Grid Background="{DynamicResource BackgroundBrush}">
         <Grid.Clip>
             <RectangleGeometry RadiusX="5" RadiusY="5"
-                               Rect="0,0,920,700"/>
+                               Rect="0,0,920,720"/>
         </Grid.Clip>
         <Grid.RowDefinitions>
             <RowDefinition Height="30" />
@@ -119,7 +119,7 @@
         <!-- Main content -->
         <Grid Grid.Row="2" Margin="8,6,8,6">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="200" />
+                <ColumnDefinition Width="232" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="280" />
             </Grid.ColumnDefinitions>
@@ -159,7 +159,8 @@
                                        Margin="0,0,0,2" />
                             <ComboBox ItemsSource="{Binding GroupCollapseModes}"
                                       SelectedItem="{Binding GroupCollapseMode}"
-                                      FontSize="11" Width="175">
+                                      FontSize="11" Width="184"
+                                      HorizontalAlignment="Left">
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate>
                                         <TextBlock Text="{Binding Converter={StaticResource EnumDescriptionConverter}}" />
@@ -188,7 +189,7 @@
                         <TextBlock Text="BACKGROUND OPACITY" Style="{StaticResource SectionLabel}" />
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
                             <Slider Value="{Binding BackgroundOpacity, Delay=400}" Minimum="0" Maximum="1"
-                                    Width="110" VerticalAlignment="Center" />
+                                    Width="155" VerticalAlignment="Center" />
                             <TextBlock Text="{Binding BackgroundOpacity, StringFormat={}{0:F2}}"
                                        Foreground="{DynamicResource OverlayFieldBrush}" FontSize="11" Margin="6,0,0,0"
                                        VerticalAlignment="Center" />
@@ -201,7 +202,8 @@
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
                             <TextBox Text="{Binding CustomCss, UpdateSourceTrigger=PropertyChanged}"
                                      Height="250"
-                                     Width="150"
+                                     Width="185"
+                                     HorizontalAlignment="Left"
                                      AcceptsTab="True"
                                      AcceptsReturn="True"
                                      VerticalScrollBarVisibility="Auto" />
@@ -560,13 +562,13 @@
 
                         <TextBlock Text="TEXT" Style="{StaticResource SectionLabel}" Margin="0,0,0,4" />
                         <TextBox Text="{Binding TitleText, UpdateSourceTrigger=PropertyChanged, Delay=400}"
-                                 Margin="0,0,0,8" Width="230" HorizontalAlignment="Left" />
+                                 Margin="0,0,0,8" Width="235" HorizontalAlignment="Left" />
 
                         <TextBlock Text="FONT FAMILY" Style="{StaticResource SectionLabel}" Margin="0,0,0,4" />
                         <ComboBox ItemsSource="{Binding AvailableFonts}"
                                   SelectedItem="{Binding TitleFontFamily}"
                                   Margin="0,0,0,8"
-                                  FontSize="11" Width="230" HorizontalAlignment="Left">
+                                  FontSize="11" Width="235" HorizontalAlignment="Left">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate>
                                     <TextBlock Text="{Binding}" FontFamily="{Binding}" />
@@ -588,7 +590,7 @@
                         <ComboBox ItemsSource="{Binding AvailableFonts}"
                                   SelectedItem="{Binding HeaderFontFamily}"
                                   Margin="0,0,0,8"
-                                  FontSize="11" Width="230" HorizontalAlignment="Left">
+                                  FontSize="11" Width="235" HorizontalAlignment="Left">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate>
                                     <TextBlock Text="{Binding}" FontFamily="{Binding}" />
@@ -610,7 +612,7 @@
                         <ComboBox ItemsSource="{Binding AvailableFonts}"
                                   SelectedItem="{Binding GroupHeaderFontFamily}"
                                   Margin="0,0,0,8"
-                                  FontSize="11" Width="230" HorizontalAlignment="Left">
+                                  FontSize="11" Width="235" HorizontalAlignment="Left">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate>
                                     <TextBlock Text="{Binding}" FontFamily="{Binding}" />
@@ -638,7 +640,7 @@
                         <ComboBox ItemsSource="{Binding AvailableFonts}"
                                   SelectedItem="{Binding FontFamily}"
                                   Margin="0,0,0,8"
-                                  FontSize="11" Width="230" HorizontalAlignment="Left">
+                                  FontSize="11" Width="235" HorizontalAlignment="Left">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate>
                                     <TextBlock Text="{Binding}" FontFamily="{Binding}" />
@@ -660,7 +662,7 @@
                         <ComboBox ItemsSource="{Binding AvailableFonts}"
                                   SelectedItem="{Binding FooterFontFamily}"
                                   Margin="0,0,0,8"
-                                  FontSize="11" Width="230" HorizontalAlignment="Left">
+                                  FontSize="11" Width="235" HorizontalAlignment="Left">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate>
                                     <TextBlock Text="{Binding}" FontFamily="{Binding}" />
@@ -681,7 +683,7 @@
                         <ComboBox ItemsSource="{Binding AvailableFonts}"
                                   SelectedItem="{Binding IgtFontFamily}"
                                   Margin="0,0,0,8"
-                                  FontSize="11" Width="230" HorizontalAlignment="Left">
+                                  FontSize="11" Width="235" HorizontalAlignment="Left">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate>
                                     <TextBlock Text="{Binding}" FontFamily="{Binding}" />
@@ -699,13 +701,13 @@
 
                         <TextBlock Text="RUN COMPLETION MESSAGE" Style="{StaticResource SectionLabel}" Margin="0,0,0,4" />
                         <TextBox Text="{Binding RunCompleteText, UpdateSourceTrigger=PropertyChanged, Delay=400}"
-                                 Margin="0,0,0,8" Width="230" HorizontalAlignment="Left" />
+                                 Margin="0,0,0,8" Width="235" HorizontalAlignment="Left" />
 
 
                         <Separator Style="{StaticResource Separator}" />
 
                         <TextBlock Text="STYLE" Style="{StaticResource SectionLabel}" />
-                        <TextBlock Text="Applies to all but title, run completion, and group headers." FontSize="10"
+                        <TextBlock Text="Doesn't apply to title, run completion, or group headers." FontSize="10"
                                    FontStyle="Italic"
                                    Foreground="{DynamicResource OverlayCommentsBrush}" Margin="0,-4,0,4" />
                         <CheckBox Content="Bold" IsChecked="{Binding FontBold}" Margin="0,3,0,3" />

--- a/AutoHitCounter/Views/Windows/OverlaySettingsWindow.xaml
+++ b/AutoHitCounter/Views/Windows/OverlaySettingsWindow.xaml
@@ -273,6 +273,45 @@
 
                         <Separator Style="{StaticResource Separator}" Margin="0,0,10,0" />
 
+                        <TextBlock Text="GROUP HEADERS" Style="{StaticResource SectionLabel}" />
+                        <StackPanel Style="{StaticResource ColorRow}">
+                            <TextBlock Text="Group Name" Style="{StaticResource FieldLabel}" />
+                            <Border Width="24" Height="22" BorderBrush="#444" BorderThickness="1" Margin="0,0,4,0">
+                                <Rectangle
+                                    Fill="{Binding GroupNameColor, Converter={StaticResource StringToBrushConverter}}" />
+                            </Border>
+                            <TextBox Text="{Binding GroupNameColor, UpdateSourceTrigger=PropertyChanged}" Width="150" />
+                        </StackPanel>
+                        <StackPanel Style="{StaticResource ColorRow}">
+                            <TextBlock Text="Hits" Style="{StaticResource FieldLabel}" />
+                            <Border Width="24" Height="22" BorderBrush="#444" BorderThickness="1" Margin="0,0,4,0">
+                                <Rectangle
+                                    Fill="{Binding GroupHeaderHitsColor, Converter={StaticResource StringToBrushConverter}}" />
+                            </Border>
+                            <TextBox Text="{Binding GroupHeaderHitsColor, UpdateSourceTrigger=PropertyChanged}"
+                                     Width="150" />
+                        </StackPanel>
+                        <StackPanel Style="{StaticResource ColorRow}">
+                            <TextBlock Text="Hits (totals &gt; 0)" Style="{StaticResource FieldLabel}" />
+                            <Border Width="24" Height="22" BorderBrush="#444" BorderThickness="1" Margin="0,0,4,0">
+                                <Rectangle
+                                    Fill="{Binding GroupHeaderHitsHighlightColor, Converter={StaticResource StringToBrushConverter}}" />
+                            </Border>
+                            <TextBox Text="{Binding GroupHeaderHitsHighlightColor, UpdateSourceTrigger=PropertyChanged}"
+                                     Width="150" />
+                        </StackPanel>
+                        <StackPanel Style="{StaticResource ColorRow}">
+                            <TextBlock Text="PB Column" Style="{StaticResource FieldLabel}" />
+                            <Border Width="24" Height="22" BorderBrush="#444" BorderThickness="1" Margin="0,0,4,0">
+                                <Rectangle
+                                    Fill="{Binding GroupHeaderPbColor, Converter={StaticResource StringToBrushConverter}}" />
+                            </Border>
+                            <TextBox Text="{Binding GroupHeaderPbColor, UpdateSourceTrigger=PropertyChanged}"
+                                     Width="150" />
+                        </StackPanel>
+
+                        <Separator Style="{StaticResource Separator}" Margin="0,0,10,0" />
+
                         <TextBlock Text="ATTEMPTS COUNTER" Style="{StaticResource SectionLabel}" />
                         <StackPanel Style="{StaticResource ColorRow}">
                             <TextBlock Text="When Zero" Style="{StaticResource FieldLabel}" />
@@ -296,15 +335,6 @@
                         <Separator Style="{StaticResource Separator}" Margin="0,0,10,0" />
 
                         <TextBlock Text="SPLITS" Style="{StaticResource SectionLabel}" />
-
-                        <StackPanel Style="{StaticResource ColorRow}">
-                            <TextBlock Text="Group Name" Style="{StaticResource FieldLabel}" />
-                            <Border Width="24" Height="22" BorderBrush="#444" BorderThickness="1" Margin="0,0,4,0">
-                                <Rectangle
-                                    Fill="{Binding GroupNameColor, Converter={StaticResource StringToBrushConverter}}" />
-                            </Border>
-                            <TextBox Text="{Binding GroupNameColor, UpdateSourceTrigger=PropertyChanged}" Width="150" />
-                        </StackPanel>
 
                         <StackPanel Style="{StaticResource ColorRow}">
                             <TextBlock Text="Split Name" Style="{StaticResource FieldLabel}" />
@@ -574,6 +604,34 @@
 
                         <Separator Style="{StaticResource Separator}" />
 
+                        <TextBlock Text="GROUP HEADER TEXT" Style="{StaticResource PanelHeader}" />
+
+                        <TextBlock Text="FONT FAMILY" Style="{StaticResource SectionLabel}" Margin="0,0,0,4" />
+                        <ComboBox ItemsSource="{Binding AvailableFonts}"
+                                  SelectedItem="{Binding GroupHeaderFontFamily}"
+                                  Margin="0,0,0,8"
+                                  FontSize="11" Width="230" HorizontalAlignment="Left">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding}" FontFamily="{Binding}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+
+                        <TextBlock Text="SIZE" Style="{StaticResource SectionLabel}" />
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                            <TextBlock Text="Font Size" Style="{StaticResource FieldLabel}" Width="90" />
+                            <xctk:IntegerUpDown Value="{Binding GroupHeaderFontSize}" Minimum="2" Maximum="64"
+                                                Width="55" />
+                        </StackPanel>
+
+                        <TextBlock Text="TEXT STYLE" Style="{StaticResource SectionLabel}" />
+                        <CheckBox Content="Bold" IsChecked="{Binding GroupHeaderBold}" Margin="0,3,0,3" />
+                        <CheckBox Content="Italic" IsChecked="{Binding GroupHeaderItalic}" Margin="0,3,0,3" />
+                        <CheckBox Content="Underline" IsChecked="{Binding GroupHeaderUnderline}" Margin="0,3,12,3" />
+
+                        <Separator Style="{StaticResource Separator}" />
+
                         <TextBlock Text="SPLITS TEXT" Style="{StaticResource PanelHeader}" />
 
                         <TextBlock Text="FONT FAMILY" Style="{StaticResource SectionLabel}" Margin="0,0,0,4" />
@@ -647,7 +705,8 @@
                         <Separator Style="{StaticResource Separator}" />
 
                         <TextBlock Text="STYLE" Style="{StaticResource SectionLabel}" />
-                        <TextBlock Text="Applies to all but title and run completion." FontSize="10" FontStyle="Italic"
+                        <TextBlock Text="Applies to all but title, run completion, and group headers." FontSize="10"
+                                   FontStyle="Italic"
                                    Foreground="{DynamicResource OverlayCommentsBrush}" Margin="0,-4,0,4" />
                         <CheckBox Content="Bold" IsChecked="{Binding FontBold}" Margin="0,3,0,3" />
                         <CheckBox Content="Italic" IsChecked="{Binding FontItalic}" Margin="0,3,0,3" />


### PR DESCRIPTION
Added 2 features:
1) Minimize groups. This feature will allow 3 settings for collapsing groups: none (current state), Collapse all, and Collapse Completed.

2) Group split progress. This feature has 3 settings as well: None (current state), Display only current group split progress, Display all group split progress.

App number will likely need updated.