### PR TITLE
Feat/restart igt for no fresh start runs

### DIFF
--- a/AutoHitCounter.Tests/ViewModels/MainViewModelTests.cs
+++ b/AutoHitCounter.Tests/ViewModels/MainViewModelTests.cs
@@ -530,4 +530,109 @@ public class MainViewModelTests
     }
 
     #endregion
+
+    #region IGT offset
+
+    [Fact]
+    public void InGameTime_WithNoOffset_ReflectsRawIgt()
+    {
+        _orchestrator.TimeChangedMs += Raise.Event<Action<long>>(90000L);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(90000), _sut.InGameTime);
+        Assert.Equal("0:01:30", _sut.InGameTimeFormatted);
+    }
+
+    [Fact]
+    public void InGameTime_AfterSettingOffset_ShowsRelativeTime()
+    {
+        _orchestrator.TimeChangedMs += Raise.Event<Action<long>>(90000L);
+
+        _sut.ResetIgtCommand.Execute(null);
+
+        _orchestrator.TimeChangedMs += Raise.Event<Action<long>>(120000L);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(30000), _sut.InGameTime);
+        Assert.Equal("0:00:30", _sut.InGameTimeFormatted);
+    }
+
+    [Fact]
+    public void InGameTime_AfterClearingOffset_ReturnsToRawIgt()
+    {
+        _orchestrator.TimeChangedMs += Raise.Event<Action<long>>(90000L);
+        _sut.ResetIgtCommand.Execute(null);
+        _orchestrator.TimeChangedMs += Raise.Event<Action<long>>(120000L);
+
+        _sut.ResetIgtCommand.Execute(null);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(120000), _sut.InGameTime);
+        Assert.Equal("0:02:00", _sut.InGameTimeFormatted);
+    }
+
+    [Fact]
+    public void HasIgtOffset_IsFalseByDefault()
+    {
+        Assert.False(_sut.HasIgtOffset);
+    }
+
+    [Fact]
+    public void HasIgtOffset_IsTrueAfterSettingOffset()
+    {
+        _orchestrator.TimeChangedMs += Raise.Event<Action<long>>(90000L);
+
+        _sut.ResetIgtCommand.Execute(null);
+
+        Assert.True(_sut.HasIgtOffset);
+    }
+
+    [Fact]
+    public void HasIgtOffset_IsFalseAfterClearingOffset()
+    {
+        _orchestrator.TimeChangedMs += Raise.Event<Action<long>>(90000L);
+        _sut.ResetIgtCommand.Execute(null);
+
+        _sut.ResetIgtCommand.Execute(null);
+
+        Assert.False(_sut.HasIgtOffset);
+    }
+
+    [Fact]
+    public void RestoreFromSavedRun_RestoresOffset()
+    {
+        var profile = SetupProfileWithSplits(("Boss", SplitType.Child));
+        profile.SavedRun = new RunState
+        {
+            CurrentSplitIndex = 0,
+            HitCounts = new[] { 0 },
+            IsRunComplete = false,
+            IgtMilliseconds = 30000,
+            IgtOffsetMilliseconds = 90000
+        };
+        _runStateService.RestoreFromSavedRun(Arg.Any<System.Collections.Generic.IList<SplitViewModel>>(), Arg.Any<RunState>())
+            .Returns(_sut.Splits[0]);
+
+        _sut.ActiveProfile = profile;
+
+        Assert.True(_sut.HasIgtOffset);
+        Assert.Equal(TimeSpan.FromMilliseconds(30000), _sut.InGameTime);
+    }
+
+    [Fact]
+    public void ResetIgtCommand_SavesRunState()
+    {
+        SetupProfileWithSplits(("Boss", SplitType.Child));
+        _orchestrator.TimeChangedMs += Raise.Event<Action<long>>(90000L);
+        _runStateService.ClearReceivedCalls();
+
+        _sut.ResetIgtCommand.Execute(null);
+
+        _runStateService.Received().SaveRunState(
+            Arg.Any<Profile>(),
+            Arg.Any<System.Collections.Generic.IList<SplitViewModel>>(),
+            Arg.Any<SplitViewModel>(),
+            Arg.Any<bool>(),
+            Arg.Any<TimeSpan>(),
+            90000L);
+    }
+
+    #endregion
 }

--- a/AutoHitCounter.Tests/ViewModels/MainViewModelTests.cs
+++ b/AutoHitCounter.Tests/ViewModels/MainViewModelTests.cs
@@ -610,6 +610,7 @@ public class MainViewModelTests
         _runStateService.RestoreFromSavedRun(Arg.Any<System.Collections.Generic.IList<SplitViewModel>>(), Arg.Any<RunState>())
             .Returns(_sut.Splits[0]);
 
+        _sut.ActiveProfile = null;
         _sut.ActiveProfile = profile;
 
         Assert.True(_sut.HasIgtOffset);

--- a/AutoHitCounter/Interfaces/IRunStateService.cs
+++ b/AutoHitCounter/Interfaces/IRunStateService.cs
@@ -9,7 +9,7 @@ namespace AutoHitCounter.Interfaces;
 
 public interface IRunStateService
 {
-    void SaveRunState(Profile profile, IList<SplitViewModel> splits, SplitViewModel currentSplit, bool isRunComplete, TimeSpan inGameTime);
+    void SaveRunState(Profile profile, IList<SplitViewModel> splits, SplitViewModel currentSplit, bool isRunComplete, TimeSpan inGameTime, long igtOffsetMs = 0);
     void CancelPendingSave();
     void FlushRunState(Profile profile);
     RunSnapshot Capture(IList<SplitViewModel> splits, SplitViewModel currentSplit, bool isRunComplete, TimeSpan inGameTime);

--- a/AutoHitCounter/MainWindow.xaml
+++ b/AutoHitCounter/MainWindow.xaml
@@ -998,12 +998,12 @@
                                     Margin="0,0,5,5">
                             <Button Command="{Binding ResetIgtCommand}"
                                     ToolTip="Toggle IGT offset (non-fresh-start runs)"
-                                    Padding="4,1"
+                                    Height="24"
                                     FontSize="11"
                                     VerticalAlignment="Center"
                                     Margin="0,0,6,0">
                                 <Button.Style>
-                                    <Style TargetType="Button">
+                                    <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
                                         <Setter Property="Content" Value="↺ IGT" />
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding HasIgtOffset}" Value="True">

--- a/AutoHitCounter/MainWindow.xaml
+++ b/AutoHitCounter/MainWindow.xaml
@@ -996,6 +996,23 @@
                                     VerticalAlignment="Bottom"
                                     Orientation="Horizontal"
                                     Margin="0,0,5,5">
+                            <Button Command="{Binding ResetIgtCommand}"
+                                    ToolTip="Toggle IGT offset (non-fresh-start runs)"
+                                    Padding="4,1"
+                                    FontSize="11"
+                                    VerticalAlignment="Center"
+                                    Margin="0,0,6,0">
+                                <Button.Style>
+                                    <Style TargetType="Button">
+                                        <Setter Property="Content" Value="↺ IGT" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding HasIgtOffset}" Value="True">
+                                                <Setter Property="Content" Value="✕ IGT" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+                            </Button>
                             <TextBlock Text="{Binding TimerLabel}"
                                        FontSize="12"
                                        Foreground="#888"

--- a/AutoHitCounter/Models/RunState.cs
+++ b/AutoHitCounter/Models/RunState.cs
@@ -8,4 +8,5 @@ public class RunState
     public int[] HitCounts { get; set; }
     public bool IsRunComplete { get; set; }
     public long IgtMilliseconds { get; set; }
+    public long IgtOffsetMilliseconds { get; set; }
 }

--- a/AutoHitCounter/Services/RunStateService.cs
+++ b/AutoHitCounter/Services/RunStateService.cs
@@ -28,7 +28,7 @@ public class RunStateService : IRunStateService
         };
     }
 
-    public void SaveRunState(Profile profile, IList<SplitViewModel> splits, SplitViewModel currentSplit, bool isRunComplete, TimeSpan inGameTime)
+    public void SaveRunState(Profile profile, IList<SplitViewModel> splits, SplitViewModel currentSplit, bool isRunComplete, TimeSpan inGameTime, long igtOffsetMs = 0)
     {
         if (profile == null) return;
 
@@ -38,7 +38,8 @@ public class RunStateService : IRunStateService
             CurrentSplitIndex = currentSplit != null ? splits.IndexOf(currentSplit) : -1,
             HitCounts = children.Select(s => s.NumOfHits).ToArray(),
             IsRunComplete = isRunComplete,
-            IgtMilliseconds = (long)inGameTime.TotalMilliseconds
+            IgtMilliseconds = (long)inGameTime.TotalMilliseconds,
+            IgtOffsetMilliseconds = igtOffsetMs
         };
 
         _pendingProfile = profile;

--- a/AutoHitCounter/ViewModels/MainViewModel.cs
+++ b/AutoHitCounter/ViewModels/MainViewModel.cs
@@ -26,6 +26,8 @@ namespace AutoHitCounter.ViewModels
         private readonly IOverlayServerService _overlayServerService;
         private readonly ICustomGameService _customGameService;
         private string _lastIgt;
+        private long _rawIgtMs;
+        private long _igtOffsetMs;
         private readonly IRunStateService _runStateService;
         private readonly IGameSessionOrchestrator _orchestrator;
 
@@ -138,6 +140,8 @@ namespace AutoHitCounter.ViewModels
         public DelegateCommand MoveSplitDownCommand { get; set; }
 
         public DelegateCommand SetDistancePbCommand { get; set; }
+
+        public DelegateCommand ResetIgtCommand { get; set; }
 
         #endregion
 
@@ -310,6 +314,8 @@ namespace AutoHitCounter.ViewModels
             get => _inGameTime;
             set => SetProperty(ref _inGameTime, value);
         }
+
+        public bool HasIgtOffset => _igtOffsetMs > 0;
 
         private bool _isPracticeMode;
 
@@ -524,7 +530,7 @@ namespace AutoHitCounter.ViewModels
         }
 
         public void SaveRunState() =>
-            _runStateService.SaveRunState(_activeProfile, Splits, CurrentSplit, IsRunComplete, InGameTime);
+            _runStateService.SaveRunState(_activeProfile, Splits, CurrentSplit, IsRunComplete, InGameTime, _igtOffsetMs);
 
         public void FlushRunState() => _runStateService.FlushRunState(_activeProfile);
 
@@ -559,6 +565,7 @@ namespace AutoHitCounter.ViewModels
             IncrementHitCommand = new DelegateCommand(IncrementHit);
             DecrementHitCommand = new DelegateCommand(DecrementHit);
             ResetCommand = new DelegateCommand(ResetSplits);
+            ResetIgtCommand = new DelegateCommand(ToggleIgtOffset);
             SetPbCommand = new DelegateCommand(SetPb);
             SetDistancePbCommand = new DelegateCommand(SetDistancePb, CanSetDistancePb);
 
@@ -712,7 +719,8 @@ namespace AutoHitCounter.ViewModels
 
         private void UpdateInGameTime(long igt)
         {
-            InGameTime = TimeSpan.FromMilliseconds(igt);
+            _rawIgtMs = igt;
+            InGameTime = TimeSpan.FromMilliseconds(Math.Max(0L, igt - _igtOffsetMs));
             var formatted = $"{(int)InGameTime.TotalHours}:{InGameTime.Minutes:D2}:{InGameTime.Seconds:D2}";
             if (formatted != _lastIgt)
             {
@@ -720,6 +728,14 @@ namespace AutoHitCounter.ViewModels
                 InGameTimeFormatted = formatted;
                 _overlayServerService.BroadcastIgt(formatted);
             }
+        }
+
+        private void ToggleIgtOffset()
+        {
+            _igtOffsetMs = _igtOffsetMs > 0 ? 0L : _rawIgtMs;
+            OnPropertyChanged(nameof(HasIgtOffset));
+            UpdateInGameTime(_rawIgtMs);
+            SaveRunState();
         }
 
         private ProfileEditorWindow _profileEditorWindow;
@@ -1129,6 +1145,8 @@ namespace AutoHitCounter.ViewModels
         {
             var toRestore = _runStateService.RestoreFromSavedRun(Splits, state);
             _splitNav.SetPosition(toRestore, state.IsRunComplete);
+            _igtOffsetMs = state.IgtOffsetMilliseconds;
+            OnPropertyChanged(nameof(HasIgtOffset));
             InGameTime = TimeSpan.FromMilliseconds(state.IgtMilliseconds);
         }
 


### PR DESCRIPTION
Adds a new button to restart the IGT, so you can start from 00:00:00 in non fresh start runs, like NG+/DLC% runs.

The button toggles between the real IGT and the relative IGT.

<img width="1199" height="480" alt="image" src="https://github.com/user-attachments/assets/8ff09ce2-702d-460f-89c9-f1fa3ad61c46" />

<img width="1135" height="409" alt="image" src="https://github.com/user-attachments/assets/69f93500-5182-4007-8c72-8b08647a03ba" />
